### PR TITLE
Volume count fix with the AniList tracker

### DIFF
--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -326,7 +326,7 @@ export class Anilist extends Tracker {
                 let mutation: GraphQLQuery
                 const status = values['status']?.[0] ?? ''
                 const id = values['id'] != null ? Number(values['id']) : undefined
-		        const progressVolumes = values['progressVolumes'] != null ? Number(values['progressVolumes']) : undefined
+		        const progressVolumes = values['progressVolumes'] ? Number(values['progressVolumes']) : undefined
 
 
                 if(status == 'NONE' && id != null) {

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -1,3 +1,33 @@
+Skip to content
+Search or jump to…
+Pull requests
+Issues
+Marketplace
+Explore
+ 
+@Celarye 
+Paperback-iOS
+/
+trackers-main
+Public
+Code
+Issues
+Pull requests
+1
+Actions
+Projects
+Wiki
+Security
+Insights
+trackers-main/src/Anilist/Anilist.ts /
+@swaggy-p-jp
+swaggy-p-jp bump version
+Latest commit 5877098 on 21 Sep 2021
+ History
+ 2 contributors
+@FaizanDurrani@swaggy-p-jp
+468 lines (422 sloc)  18.5 KB
+   
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
     ContentRating,
@@ -326,6 +356,8 @@ export class Anilist extends Tracker {
                 let mutation: GraphQLQuery
                 const status = values['status']?.[0] ?? ''
                 const id = values['id'] != null ? Number(values['id']) : undefined
+		        const progressVolumes = values['progressVolumes'] != null ? Number(values['progressVolumes']) : undefined
+
 
                 if(status == 'NONE' && id != null) {
                     mutation = deleteMangaProgressMutation(id)
@@ -336,7 +368,7 @@ export class Anilist extends Tracker {
                         status: status,
                         notes: values['notes'],
                         progress: Number(values['progress']),
-                        progressVolumes: Number(values['progressVolumes']),
+                        progressVolumes: progressVolumes,
                         score: Number(values['score'])
                     })
                 }
@@ -465,4 +497,16 @@ export class Anilist extends Tracker {
         return extracted != null ? Number(extracted) : undefined
     }
 }
-
+© 2022 GitHub, Inc.
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+Loading complete

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -1,33 +1,3 @@
-Skip to content
-Search or jump to…
-Pull requests
-Issues
-Marketplace
-Explore
- 
-@Celarye 
-Paperback-iOS
-/
-trackers-main
-Public
-Code
-Issues
-Pull requests
-1
-Actions
-Projects
-Wiki
-Security
-Insights
-trackers-main/src/Anilist/Anilist.ts /
-@swaggy-p-jp
-swaggy-p-jp bump version
-Latest commit 5877098 on 21 Sep 2021
- History
- 2 contributors
-@FaizanDurrani@swaggy-p-jp
-468 lines (422 sloc)  18.5 KB
-   
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
     ContentRating,
@@ -497,16 +467,3 @@ export class Anilist extends Tracker {
         return extracted != null ? Number(extracted) : undefined
     }
 }
-© 2022 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About
-Loading complete


### PR DESCRIPTION
A fix that prevents that the tracker sets the volume count to 0 if there is no volume specified by the source (instead it leaves the volumes as is).