### PR TITLE
[Anilist] bug fixes

### DIFF
--- a/src/Anilist/AlSettings.ts
+++ b/src/Anilist/AlSettings.ts
@@ -5,7 +5,7 @@ import {
 } from 'paperback-extensions-common'
 
 export const getdefaultStatus = async (stateManager: SourceStateManager): Promise<string[]> => {
-    return (await stateManager.retrieve('defaultStatus') as string[]) ?? undefined
+    return (await stateManager.retrieve('defaultStatus') as string[]) ?? ['NONE']
 }
 
 export const trackerSettings = (stateManager: SourceStateManager): NavigationButton => {
@@ -27,14 +27,12 @@ export const trackerSettings = (stateManager: SourceStateManager): NavigationBut
                     createSection({
                         id: 'settings',
                         rows: () => {
-                            return Promise.all([
-                                getdefaultStatus(stateManager)
-                            ]).then(async values => {
+                            return getdefaultStatus(stateManager).then((values) => {
                                 return [
                                     createSelect({
                                         id: 'defaultStatus',
                                         label: 'Default Status',
-                                        value: values[0] ?? 'NONE',
+                                        value: values,
                                         displayLabel: (value) => {
                                             switch (value) {
                                                 case 'CURRENT': return 'Reading'
@@ -55,7 +53,7 @@ export const trackerSettings = (stateManager: SourceStateManager): NavigationBut
                                             'PAUSED',
                                             'REPEATING'
                                         ]
-                                    
+
                                     })
                                 ]
                             })

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -24,7 +24,10 @@ import * as AnilistUser from './models/anilist-user'
 import * as AnilistPage from './models/anilist-page'
 import * as AnilistManga from './models/anilist-manga'
 import { AnilistResult } from './models/anilist-result'
-import { getdefaultStatus, trackerSettings } from './AlSettings'
+import {
+    getdefaultStatus,
+    trackerSettings
+} from './AlSettings'
 
 const ANILIST_GRAPHQL_ENDPOINT = 'https://graphql.anilist.co/'
 const FALLBACK_IMAGE = 'https://via.placeholder.com/100x150'
@@ -239,7 +242,9 @@ export class Anilist extends Tracker {
                         rows: async () => [
                             createSelect({
                                 id: 'status',
-                                value: [anilistManga.mediaListEntry?.status ?? (await getdefaultStatus(this.stateManager)).toString()],
+                                value: anilistManga.mediaListEntry?.status
+                                    ? [anilistManga.mediaListEntry.status]
+                                    : (await getdefaultStatus(this.stateManager)),
                                 allowsMultiselect: false,
                                 label: 'Status',
                                 displayLabel: (value) => {

--- a/src/Anilist/Anilist.ts
+++ b/src/Anilist/Anilist.ts
@@ -38,7 +38,7 @@ export const AnilistInfo: SourceInfo = {
     author: 'Faizan Durrani',
     contentRating: ContentRating.EVERYONE,
     icon: 'icon.png',
-    version: '1.0.9',
+    version: '1.0.10',
     description: 'Anilist Tracker',
     authorWebsite: 'faizandurrani.github.io',
     websiteBaseURL: 'https://anilist.co'

--- a/src/Anilist/models/graphql-queries.ts
+++ b/src/Anilist/models/graphql-queries.ts
@@ -126,7 +126,7 @@ export const getMangaProgressQuery = (id: number): GraphQLQuery => ({
 
 export interface SaveMangaProgressVariables {
     id?: number
-    mediaId?: number
+    mediaId?: number | string
     status?: string
     score?: number
     progress?: number


### PR DESCRIPTION
This PR fixes two bugs in the Anilist tracker:

1. Handle `defaultStatus` not being defined in state. Currently this produces an error toast message.
2. Handle point-chapters (e.g. `7.1`). Anilist's API currently rejects these requests, causing the action queue to not get cleared.