### PR TITLE
fix: support MangaUpdates manga with empty descriptions

### DIFF
--- a/src/MangaUpdates/MangaUpdates.ts
+++ b/src/MangaUpdates/MangaUpdates.ts
@@ -72,7 +72,7 @@ export const MangaUpdatesInfo: SourceInfo = {
     author: 'IntermittentlyRupert',
     contentRating: ContentRating.EVERYONE,
     icon: 'icon.png',
-    version: '2.0.0',
+    version: '2.0.1',
     description: 'MangaUpdates Tracker',
     websiteBaseURL: 'https://www.mangaupdates.com',
 }

--- a/src/MangaUpdates/utils/mu-manga.ts
+++ b/src/MangaUpdates/utils/mu-manga.ts
@@ -63,7 +63,7 @@ export function parseMangaInfo(series: MUSeriesModelV1): Manga {
             series.title,
             ...(series.associated || []).map(associated => associated?.title)
         ].filter((title): title is string => !!title),
-        desc: series.description,
+        desc: series.description || '',
         image: series.image?.url?.original || '',
 
         author: series.authors?.filter(author => author?.type === 'Author' && author.name).map(author => author.name).join(', '),


### PR DESCRIPTION
Turns out this field _isn't_ optional.